### PR TITLE
Removed further references to a Google integration

### DIFF
--- a/byers/src/main.rs
+++ b/byers/src/main.rs
@@ -122,7 +122,6 @@ async fn main() {
         comms: std::sync::Arc::new(tokio::sync::Mutex::new(
             ByersUnixStream::new().await.unwrap(),
         )),
-        google_config: config.google,
         redis_pool: redis_pool.clone(),
         redis_subscriber: subscriber_client.clone(),
     };

--- a/byers/src/prelude.rs
+++ b/byers/src/prelude.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use lazy_static::lazy_static;
 use tokio::sync::Mutex;
 
-use crate::app_config::GoogleConfig;
 use judeharley::communication::{ByersUnixStream, LiquidsoapCommunication};
 
 lazy_static! {
@@ -25,7 +24,6 @@ where
 {
     pub db: judeharley::PgPool,
     pub comms: Arc<Mutex<C>>,
-    pub google_config: GoogleConfig,
     pub redis_pool: fred::pool::RedisPool,
     pub redis_subscriber: fred::clients::SubscriberClient,
 }


### PR DESCRIPTION
Removed references to a Google integration that prevented compilation. Cozy removed a struct, but not the things referring to it. Grepping through the repository, there is no further mention of Google, making it clear that the integration is nonfunctional. If this is in error, please let me know.